### PR TITLE
Added setting to disable the required item for evolutions

### DIFF
--- a/include/pksavhelper.h
+++ b/include/pksavhelper.h
@@ -144,6 +144,7 @@ static const struct pkmn_evolution_pair_data pkmn_evolution_pairs[MAX_SPECIES_IN
 };
 
 static bool disable_random_DVs_on_trade = false;
+static bool item_required_evolutions = true;
 
 int error_handler(enum pksav_error error, const char *message);
 void swap_party_pkmn_at_indices(struct pksav_gen2_save *pkmn_save, uint8_t pkmn_index1, uint8_t pkmn_index2); // TODO: Update for cross-generation
@@ -152,13 +153,15 @@ void create_trainer(PokemonSave *pkmn_save, struct TrainerInfo *trainer);
 void update_seen_owned_pkmn(PokemonSave *pkmn_save, uint8_t pkmn_party_index);
 void create_trainer_name_str(const struct TrainerInfo *trainer, char *trainer_name, bool show_gender);
 void create_trainer_id_str(const struct TrainerInfo *trainer, char *trainer_id);
-int check_trade_evolution_gen1(PokemonSave *pkmn_save, uint8_t pkmn_party_index);
+enum eligible_evolution_status check_trade_evolution_gen1(PokemonSave *pkmn_save, uint8_t pkmn_party_index);
 enum eligible_evolution_status check_trade_evolution_gen2(PokemonSave *pkmn_save, uint8_t pkmn_party_index);
 void evolve_party_pokemon_at_index(PokemonSave *pkmn_save, uint8_t pkmn_party_index);
 void generate_random_number_step(void);
 void update_pkmn_DVs(PokemonSave *pkmn_save, uint8_t pkmn_party_index);
 bool get_is_random_DVs_disabled(void);
 void set_is_random_DVs_disabled(bool is_disabled);
+bool get_is_item_required(void);
+void set_is_item_required(bool is_required);
 void generate_rand_num_step(SaveGenerationType save_generation_type);
 
 #endif /* PKSAVHELPER_H */

--- a/include/raylibhelper.h
+++ b/include/raylibhelper.h
@@ -15,7 +15,7 @@ void draw_file_select(struct SaveFileData *save_file_data, char *player1_save_pa
 void draw_trade(PokemonSave *save_player1, PokemonSave *save_player2, char *player1_save_path, char *player2_save_path, struct TrainerSelection trainer_selection[2], struct TrainerInfo *trainer1, struct TrainerInfo *trainer2);
 void draw_file_select_single(struct SaveFileData *save_file_data, PokemonSave *save_player1, char *player1_save_path, struct TrainerInfo *trainer1, struct TrainerSelection *trainer_selection, enum single_player_menu_types menu_type);
 void draw_bills_pc(PokemonSave *pkmn_save, char *save_path, struct TrainerInfo *trainer, struct TrainerSelection *trainer_selection);
-void draw_evolve(PokemonSave *pkmn_save, char *save_path);
+void draw_evolve(PokemonSave *pkmn_save, char *save_path, struct TrainerInfo *trainer);
 void draw_raylib_screen_loop(
     struct SaveFileData *save_file_data,
     struct TrainerInfo *trainer1,

--- a/src/filehelper.c
+++ b/src/filehelper.c
@@ -173,6 +173,8 @@ void create_default_config(void)
     fputs(default_key, fp);
     fputs("\n", fp);
     fputs("DISABLE_RANDOM_IVS_ON_TRADE=false", fp);
+    fputs("\n", fp);
+    fputs("ITEM_REQUIRED_EVOLUTIONS=true", fp);
 
     fclose(fp);
 }

--- a/src/main.c
+++ b/src/main.c
@@ -23,6 +23,8 @@ int main(int argc, char *argv[])
 
     // Read and save the disable random setting from config.ini
     set_is_random_DVs_disabled(strcmp(read_key_from_config("DISABLE_RANDOM_IVS_ON_TRADE"), "false"));
+    // Read and save the item required evolutions setting from config.ini
+    set_is_item_required(strcmp(read_key_from_config("ITEM_REQUIRED_EVOLUTIONS"), "false"));
 
     // malloc'd from read_key_from_config
     free(config_save_path);

--- a/src/pksavhelper.c
+++ b/src/pksavhelper.c
@@ -231,38 +231,18 @@ void create_trainer_id_str(const struct TrainerInfo *trainer, char *trainer_id)
     strcat(trainer_id, id_str);
 }
 
-// Checks if supplied Gen 1 pokemon is eligible for trade evolution returns 1 if true, 0 if false
-int check_trade_evolution_gen1(PokemonSave *pkmn_save, uint8_t pkmn_party_index)
+// Checks if supplied Gen 1 pokemon is eligible for trade evolution
+enum eligible_evolution_status check_trade_evolution_gen1(PokemonSave *pkmn_save, uint8_t pkmn_party_index)
 {
     // Species index of pokemon being checked
     uint8_t species = pkmn_save->save.gen1_save.pokemon_storage.p_party->species[pkmn_party_index];
+    struct pkmn_evolution_pair_data evo_pair = pkmn_evolution_pairs[species];
 
-    // Pokemon species eligible for trade evolution in Gen 1
-    uint8_t gen1_evolutions[4] = {
-        (uint8_t)KADABRA,
-        (uint8_t)MACHOKE,
-        (uint8_t)GRAVELER,
-        (uint8_t)HAUNTER};
-
-    for (int i = 0; i < (int)(sizeof(gen1_evolutions) / sizeof(gen1_evolutions[0])); i++)
-    {
-        // Pokemon eligible for trade evolution
-        if (gen1_evolutions[i] == species)
-        {
-            return 1;
-        }
-
-        // No pokemon eligible for trade evolution
-        if (i == (int)(sizeof(gen1_evolutions) / sizeof(gen1_evolutions[0])))
-        {
-            return 0;
-        }
-    }
-
-    return 0;
+    // Check if the pokemon has an initialized evolution pair
+    return species == evo_pair.species_index;
 }
 
-// Checks if supplied Gen 2 pokemon is eligible for trade evolution returns 1 if true, 0 if false, or 2 if eligible but required missing item
+// Checks if supplied Gen 2 pokemon is eligible for trade evolution
 enum eligible_evolution_status check_trade_evolution_gen2(PokemonSave *pkmn_save, uint8_t pkmn_party_index)
 {
     // Species index of pokemon being checked
@@ -275,13 +255,13 @@ enum eligible_evolution_status check_trade_evolution_gen2(PokemonSave *pkmn_save
     if (species == evo_pair.species_index)
     {
         // Pokemon eligible for trade evolution but missing item
-        if (evo_pair.evolution_item != 0 && evo_pair.evolution_item != item)
+        if (evo_pair.evolution_item != item && get_is_item_required())
         {
             return E_EVO_STATUS_MISSING_ITEM;
         }
 
         // Pokemon eligible for trade evolution
-        if (evo_pair.evolution_item == item)
+        if (evo_pair.evolution_item == item || !get_is_item_required())
         {
             return E_EVO_STATUS_ELIGIBLE;
         }
@@ -580,4 +560,16 @@ bool get_is_random_DVs_disabled(void)
 void set_is_random_DVs_disabled(bool is_disabled)
 {
     disable_random_DVs_on_trade = is_disabled;
+}
+
+// Settings getter disable item required for trade
+bool get_is_item_required(void)
+{
+    return item_required_evolutions;
+}
+
+// Settings setter disable item required for trade
+void set_is_item_required(bool is_required)
+{
+    item_required_evolutions = is_required;
 }

--- a/src/pksavhelper.c
+++ b/src/pksavhelper.c
@@ -244,8 +244,7 @@ int check_trade_evolution_gen1(PokemonSave *pkmn_save, uint8_t pkmn_party_index)
         (uint8_t)GRAVELER,
         (uint8_t)HAUNTER};
 
-    int i;
-    for (i = 0; i < (int)(sizeof(gen1_evolutions) / sizeof(gen1_evolutions[0])); i++)
+    for (int i = 0; i < (int)(sizeof(gen1_evolutions) / sizeof(gen1_evolutions[0])); i++)
     {
         // Pokemon eligible for trade evolution
         if (gen1_evolutions[i] == species)

--- a/src/raylibhelper.c
+++ b/src/raylibhelper.c
@@ -303,6 +303,15 @@ void draw_settings(void)
     Rectangle checkbox_rec_off = (Rectangle){checkbox_rec_on.x + checkbox_rec_on.width + 5, 225, 20, 20};
     DrawRectangleLinesEx(checkbox_rec_off, 2, BLACK);
     DrawText("OFF", checkbox_rec_off.x + checkbox_rec_off.width + 5, checkbox_rec_off.y, 20, BLACK);
+    // Toggle for item override evolutions
+    DrawText("Item required for evolution", 50, 250, 20, BLACK);
+    // Checkbox for item override evolutions
+    DrawText("ON", 385, 250, 20, BLACK);
+    Rectangle checkbox_rec_on_item = (Rectangle){385 + MeasureText("ON", 20) + 5, 250, 20, 20};
+    DrawRectangleLinesEx(checkbox_rec_on_item, 2, BLACK);
+    Rectangle checkbox_rec_off_item = (Rectangle){checkbox_rec_on_item.x + checkbox_rec_on_item.width + 5, 250, 20, 20};
+    DrawRectangleLinesEx(checkbox_rec_off_item, 2, BLACK);
+    DrawText("OFF", checkbox_rec_off_item.x + checkbox_rec_off_item.width + 5, checkbox_rec_off_item.y, 20, BLACK);
 
     bool _is_rand_disabled = get_is_random_DVs_disabled();
     if (_is_rand_disabled)
@@ -315,7 +324,21 @@ void draw_settings(void)
     {
         // Draw filled in square
         DrawRectangle(checkbox_rec_off.x + 3, checkbox_rec_off.y + 3, checkbox_rec_off.width - 6, checkbox_rec_off.height - 6, BLACK);
-        DrawText("DVs will not be retained", checkbox_rec_off.x + checkbox_rec_off.width + 65, 225, 16, BLACK);
+        DrawText("DVs will not be retained (default)", checkbox_rec_off.x + checkbox_rec_off.width + 65, 225, 16, BLACK);
+    }
+
+    bool _is_item_required = get_is_item_required();
+    if (_is_item_required)
+    {
+        // Draw filled in square
+        DrawRectangle(checkbox_rec_on_item.x + 3, checkbox_rec_on_item.y + 3, checkbox_rec_on_item.width - 6, checkbox_rec_on_item.height - 6, BLACK);
+        DrawText("Items will be required (default)", checkbox_rec_off_item.x + checkbox_rec_off_item.width + 65, 250, 16, BLACK);
+    }
+    else
+    {
+        // Draw filled in square
+        DrawRectangle(checkbox_rec_off_item.x + 3, checkbox_rec_off_item.y + 3, checkbox_rec_off_item.width - 6, checkbox_rec_off_item.height - 6, BLACK);
+        DrawText("Items will not be required", checkbox_rec_off_item.x + checkbox_rec_off_item.width + 65, 250, 16, BLACK);
     }
     if (IsMouseButtonPressed(MOUSE_LEFT_BUTTON))
     {
@@ -328,6 +351,15 @@ void draw_settings(void)
         {
             set_is_random_DVs_disabled(false);
             write_key_to_config("DISABLE_RANDOM_IVS_ON_TRADE", "false");
+        } 
+        else if (CheckCollisionPointRec(GetMousePosition(), checkbox_rec_on_item))
+        {
+            set_is_item_required(true);
+            write_key_to_config("ITEM_REQUIRED_EVOLUTIONS", "true");
+        } else if (CheckCollisionPointRec(GetMousePosition(), checkbox_rec_off_item))
+        {
+            set_is_item_required(false);
+            write_key_to_config("ITEM_REQUIRED_EVOLUTIONS", "false");
         }
     }
     DrawText("About Pokerom Trader", 50, 325, 20, BLACK);
@@ -422,7 +454,7 @@ void draw_file_select(struct SaveFileData *save_file_data, char *player1_save_pa
         {
             if (IsMouseButtonPressed(MOUSE_LEFT_BUTTON))
             {
-                if (CheckCollisionPointRec(GetMousePosition(), (Rectangle){190, 75 + 25 * i, SCREEN_WIDTH / 2, 25}))
+                if (CheckCollisionPointRec(GetMousePosition(), (Rectangle){100, 75 + 25 * i, SCREEN_WIDTH / 2, 25}))
                 {
                     if (selected_saves_index[0] == i)
                     {
@@ -444,7 +476,7 @@ void draw_file_select(struct SaveFileData *save_file_data, char *player1_save_pa
             }
             char *save_name = strrchr(save_file_data->saves_file_path[i], '/');
             save_name++;
-            DrawText(save_name, 190, 75 + 25 * i, 20, (selected_saves_index[0] == i || selected_saves_index[1] == i) ? LIGHTGRAY : BLACK);
+            DrawText(save_name, 100, 75 + 25 * i, 20, (selected_saves_index[0] == i || selected_saves_index[1] == i) ? LIGHTGRAY : BLACK);
 
             // Reset generation check
             if (!isSameGeneration)
@@ -596,7 +628,7 @@ void draw_file_select_single(struct SaveFileData *save_file_data, PokemonSave *s
     {
         if (IsMouseButtonPressed(MOUSE_LEFT_BUTTON))
         {
-            if (CheckCollisionPointRec(GetMousePosition(), (Rectangle){190, 75 + 25 * i, SCREEN_WIDTH / 2, 25}))
+            if (CheckCollisionPointRec(GetMousePosition(), (Rectangle){100, 75 + 25 * i, SCREEN_WIDTH / 2, 25}))
             {
                 if (selected_saves_index == i)
                 {
@@ -613,7 +645,7 @@ void draw_file_select_single(struct SaveFileData *save_file_data, PokemonSave *s
         char *save_name = strrchr(save_file_data->saves_file_path[i], '/');
         save_name++;
 
-        DrawText(save_name, 190, 75 + 25 * i, 20, (selected_saves_index == i) ? LIGHTGRAY : BLACK);
+        DrawText(save_name, 100, 75 + 25 * i, 20, (selected_saves_index == i) ? LIGHTGRAY : BLACK);
         if (menu_type == SINGLE_PLAYER_MENU_TYPE_BILLS_PC)
             DrawText("Open Bill's PC >", NEXT_BUTTON_X, NEXT_BUTTON_Y, 20, hasSelectedSave ? BLACK : LIGHTGRAY);
         if (menu_type == SINGLE_PLAYER_MENU_TYPE_EVOLVE)
@@ -723,7 +755,7 @@ void draw_evolve(PokemonSave *pkmn_save, char *save_path, struct TrainerInfo *tr
             pksav_gen2_import_text(pkmn_save->save.gen2_save.pokemon_storage.p_party->nicknames[i], pokemon_nickname, 10);
             draw_pkmn_button((Rectangle){TRAINER_NAME_X, TRAINER_NAME_Y + 75 + (i * 30), MeasureText(pokemon_nickname, 20) + 10, 30}, i, pokemon_nickname, selected_index == i || result == E_EVO_STATUS_NOT_ELIGIBLE);
             if (result == E_EVO_STATUS_MISSING_ITEM)
-                DrawText("Missing required item!", 75 + MeasureText(pokemon_nickname, 20), 100 + (i * 30), 20, RED);
+                DrawText("Missing required item!", 75 + MeasureText(pokemon_nickname, 20), TRAINER_NAME_Y + 75 + (i * 30), 20, RED);
         }
         // Selected pokemon button
         if (CheckCollisionPointRec(GetMousePosition(), (Rectangle){TRAINER_NAME_X, TRAINER_NAME_Y + 75 + (i * 30), 200, 30}) && IsMouseButtonPressed(MOUSE_LEFT_BUTTON) && result == E_EVO_STATUS_ELIGIBLE)


### PR DESCRIPTION
Gen 2 requires a pokemon to be holding a specific item to evolve on trade. This can be disabled in settings.